### PR TITLE
feat : [015-UPDATE-CART] 카트 업데이트

### DIFF
--- a/order-api/src/main/java/com/zerobase/cms/orderapi/Controller/CustomerCartController.java
+++ b/order-api/src/main/java/com/zerobase/cms/orderapi/Controller/CustomerCartController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +35,13 @@ public class CustomerCartController {
 	public ResponseEntity<Cart> showCart(
 		@RequestHeader(name = "X-AUTH-TOKEN") String token) {
 		return ResponseEntity.ok(cartApplication.getCart(provider.getUserVo(token).getId()));
+	}
+
+	@PutMapping
+	public ResponseEntity<Cart> updateCart(
+		@RequestHeader(name = "X-AUTH-TOKEN") String token,
+		@RequestBody Cart cart) {
+		return ResponseEntity.ok(cartApplication.updateCart(provider.getUserVo(token).getId(), cart));
 	}
 
 }

--- a/order-api/src/main/java/com/zerobase/cms/orderapi/application/CartApplication.java
+++ b/order-api/src/main/java/com/zerobase/cms/orderapi/application/CartApplication.java
@@ -36,6 +36,17 @@ public class CartApplication {
 		return cartService.addCart(customerId, form);
 	}
 
+	/**
+	 * 엣지 케이스
+	 *
+	 */
+	public Cart updateCart(Long customerId, Cart cart) {
+		// 실질적으로 변하는 데이터
+		// 상품의 삭제, 수량 변경
+		cartService.putCart(customerId, cart);
+		return getCart(customerId);
+	}
+
 	// 1. 장바구니에 상품을 추가 했다.
 	// 2. 상품의 가격이나 수량이 변동 된다.
 	public Cart getCart(Long customerId) {


### PR DESCRIPTION
Changes
---
- 카트 조회 로직을 재사용하여 코드 생산성을 높였음
- 기존 카트 조회 로직에 가격과 수량, 상품의 삭제 등을 체크하는 로직이 이미 존재해, 이를 호출하여 에러 메세지와 카드의 내용을 업데이트 하는 것으로 적용

Background
---
전체적인 테스트 코드는 강의 들은 후에 작성 예정..